### PR TITLE
Add night mode support via SLEEP preset

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "WebFetch(domain:api-docs.esphome.io)",
+      "WebFetch(domain:esphome.io)",
+      "WebFetch(domain:github.com)",
+      "Bash(git checkout:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# ESPHome Climate MHI Component
+
+## Project Overview
+This is a custom ESPHome component that provides IR (infrared) climate control support for Mitsubishi Heavy Industries (MHI) air conditioners. It's a fork of the original repository at https://github.com/Dennis-Q/esphome-climate-mhi which is no longer maintained.
+
+## GitHub Repository
+- **Repository URL**: https://github.com/karllinder/esphome-climate-mhi
+- **Clone**: `gh repo clone https://github.com/karllinder/esphome-climate-mhi`
+
+## Development Workflow
+### Branching Strategy
+For major changes, please follow this workflow:
+1. Create a new branch for your feature/fix: `git checkout -b feature/your-feature-name`
+2. Make your changes and commit them
+3. Push the branch to GitHub: `git push origin feature/your-feature-name`
+4. Create a Pull Request (PR) for review
+5. After approval, merge the PR into main
+
+### Quick Fixes
+Minor fixes (typos, small bug fixes) can be committed directly to main.
+
+## Purpose
+The component enables control of MHI air conditioners through ESPHome using infrared signals, specifically designed for remote type RLA502A700K (delivered with indoor unit model SRKxxZSW-W).
+
+## Key Features
+- Full climate control integration with ESPHome
+- IR transmitter support for sending commands
+- IR receiver support for reading commands from the original remote
+- Temperature control (18°C - 30°C)
+- Multiple operating modes: Auto, Heat, Cool, Dry, Fan
+- Fan speed control: Auto, Low, Medium, High
+- Swing modes: Vertical, Horizontal, Both, Off
+- Presets: None, Eco, Boost, Activity
+- Special features: 3D Auto, Silent mode
+
+## Repository Structure
+```
+esphome-climate-mhi/
+├── README.md                    # User documentation
+├── esphome/
+│   └── components/
+│       └── mhi/                # MHI component implementation
+│           ├── __init__.py     # Python initialization (empty)
+│           ├── climate.py      # ESPHome component registration
+│           ├── mhi.h           # C++ header with class definition
+│           └── mhi.cpp         # C++ implementation
+```
+
+## Technical Details
+
+### Component Architecture
+- **climate.py**: Registers the component with ESPHome, extends `CLIMATE_IR_WITH_RECEIVER_SCHEMA`
+- **mhi.h**: Defines the `MhiClimate` class inheriting from `climate_ir::ClimateIR`
+- **mhi.cpp**: Implements IR protocol encoding/decoding for MHI air conditioners
+
+### IR Protocol
+- Uses specific timing parameters for MHI protocol
+- Header: 3200µs mark, 1600µs space
+- Bit encoding: 400µs mark with 1200µs space (1) or 400µs space (0)
+- Sends 19 bytes of data per command
+
+### Recent Changes
+- Night mode feature was recently removed (see commit history)
+- Custom preset handling was commented out
+- Hi-Power mode mapped to BOOST preset
+
+## Usage Example
+```yaml
+external_components:
+  source:
+    type: git
+    url: https://github.com/karllinder/esphome-climate-mhi
+
+remote_receiver:
+  id: rcvr
+  pin:
+    number: GPIOxx
+    inverted: true
+    mode:
+      input: true
+      pullup: true
+
+remote_transmitter:
+  pin: GPIOxx
+  carrier_duty_percent: 50%
+  
+climate:
+   - platform: mhi
+     name: "MHI"
+     receiver_id: rcvr
+```
+
+## Development Notes
+- The component uses ESPHome's climate_ir base classes for standard functionality
+- IR protocol implementation is specific to MHI RLA502A700K remote
+- Logging available under TAG "mhi.climate" for debugging
+- Supports both transmitting commands and receiving/decoding remote signals

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -52,9 +52,9 @@ namespace esphome {
         const uint8_t MHI_SILENT_ON = 0x00;
         const uint8_t MHI_SILENT_OFF = 0x80;
         
-        // Night setback - 2024-11-17 - disable for thie moment
-//        const uint8_t MHI_NIGHT_ON = 0x00;
-//        const uint8_t MHI_NIGHT_OFF = 0x40;
+        // Night setback
+        const uint8_t MHI_NIGHT_ON = 0x00;
+        const uint8_t MHI_NIGHT_OFF = 0x40;
         
         // Eco
         const uint8_t MHI_ECO_ON = 0x00;
@@ -246,7 +246,7 @@ namespace esphome {
             auto _3DAuto = MHI_3DAUTO_OFF;
             auto ecoMode = MHI_ECO_OFF;
             auto silentMode = MHI_SILENT_OFF;
-        //  auto nightMode = MHI_NIGHT_OFF;
+            auto nightMode = MHI_NIGHT_OFF;
 
             // ----------------------
             // Assign the values
@@ -337,28 +337,28 @@ namespace esphome {
                 case climate::CLIMATE_PRESET_NONE:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_OFF; //set echo mode OFF
-//                  nightMode = MHI_NIGHT_OFF; //set night off
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     break;
                 case climate::CLIMATE_PRESET_ECO:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_ON;  // set device to Eco mode
-//                  nightMode = MHI_NIGHT_OFF; //set night off
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     fanSpeed = MHI_FAN2; //set fan speed
                     break;
                 case climate::CLIMATE_PRESET_BOOST:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     fanSpeed = MHI_HIPOWER; // set device to high fan
- //                 nightMode = MHI_NIGHT_OFF; //set night off
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
                     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
- //                 nightMode = MHI_NIGHT_ON; // set nightmode on
+                    nightMode = MHI_NIGHT_OFF; // keep night mode off for activity
                     break;
-                // 2024-07-05 Added preset Night.
-  //            case climate::CLIMATE_PRESET_NIGHT:
-  //                _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
-  //                nightMode = MHI_NIGHT_ON; // set nightmode on
-  //                break;
+                case climate::CLIMATE_PRESET_SLEEP:
+                    _3DAuto = MHI_3DAUTO_OFF; // set 3dmode to off
+                    nightMode = MHI_NIGHT_ON; // set nightmode on
+                    fanSpeed = MHI_FAN1; // set fan to low for quiet operation
+                    break;
                 default: //set None to default - no action
                     break;
             }
@@ -383,7 +383,7 @@ namespace esphome {
             remote_state[13] |= swingV | swingH;
 
             // Silent and Night mode
-            remote_state[15] |= silentMode;//  | nightMode;
+            remote_state[15] |= silentMode | nightMode;
 
             // There is no real checksum, but some bytes are inverted
             remote_state[6] = ~remote_state[5];

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -53,8 +53,8 @@ namespace esphome {
         const uint8_t MHI_SILENT_OFF = 0x80;
         
         // Night setback
-        const uint8_t MHI_NIGHT_ON = 0x00;
-        const uint8_t MHI_NIGHT_OFF = 0x40;
+        const uint8_t MHI_NIGHT_ON = 0x40;
+        const uint8_t MHI_NIGHT_OFF = 0x00;
         
         // Eco
         const uint8_t MHI_ECO_ON = 0x00;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -53,8 +53,8 @@ namespace esphome {
         const uint8_t MHI_SILENT_OFF = 0x80;
         
         // Night setback
-        const uint8_t MHI_NIGHT_ON = 0x40;
-        const uint8_t MHI_NIGHT_OFF = 0x00;
+        const uint8_t MHI_NIGHT_ON = 0x00;
+        const uint8_t MHI_NIGHT_OFF = 0x40;
         
         // Eco
         const uint8_t MHI_ECO_ON = 0x00;

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -22,7 +22,8 @@ namespace esphome {
                     },
                     std::set<climate::ClimatePreset>{
                         climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO,
-                        climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ACTIVITY
+                        climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ACTIVITY,
+                        climate::CLIMATE_PRESET_SLEEP
                     }
                     //,
                 // 2024-07-05 Added custom -- possible wrong way to do this...


### PR DESCRIPTION
## Summary
- Implemented night mode functionality for MHI air conditioners
- Night mode is accessible through the SLEEP preset in Home Assistant
- Ensures quiet operation during nighttime

## Changes
- Enabled previously commented night mode constants (`MHI_NIGHT_ON`/`MHI_NIGHT_OFF`)
- Added `CLIMATE_PRESET_SLEEP` to supported presets in `mhi.h`
- Implemented night mode logic in `transmit_state()` function
- When SLEEP preset is selected:
  - Night mode is activated
  - Fan speed is set to low for quiet operation
  - 3D auto mode is disabled
- All other presets explicitly disable night mode to ensure proper state management

## Test plan
- [ ] Clean and rebuild ESPHome configuration
- [ ] Verify SLEEP preset appears in Home Assistant UI
- [ ] Test that selecting SLEEP preset activates night mode on the AC unit
- [ ] Verify fan speed is set to low when SLEEP is active
- [ ] Confirm switching to other presets disables night mode
- [ ] Test IR communication with actual MHI air conditioner

🤖 Generated with [Claude Code](https://claude.ai/code)