### PR TITLE
Fix syntax error when compiling with ESPHome 2025.11

### DIFF
--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -12,24 +12,19 @@ namespace esphome {
             public:
                 MhiClimate() : climate_ir::ClimateIR(
                     MHI_TEMP_MIN, MHI_TEMP_MAX, 1.0f, true, true,
-                    std::set<climate::ClimateFanMode>{
+                    {
                         climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
                         climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH
                     },
-                    std::set<climate::ClimateSwingMode>{
+                    {
                         climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
                         climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH
                     },
-                    std::set<climate::ClimatePreset>{
+                    {
                         climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO,
                         climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ACTIVITY,
                         climate::CLIMATE_PRESET_SLEEP
                     }
-                    //,
-                // 2024-07-05 Added custom -- possible wrong way to do this...
-                //    std::set<std::string>{
-                //        NIGHT
-                 //   }
                 ) {}
 
             protected:


### PR DESCRIPTION
Looks like the compiler was updated and requires the newer Set syntax to be used. Addresses the compiler issues preventing the component from building.