### PR TITLE
mhi.cpp: fix MODE_OFF break + drop swingV from byte 13; add compile test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,12 @@ wheels/
 
 # ESPHome
 .esphome/
+.pioenvs/
+.piolibdeps/
 secrets.yaml
+tests/.esphome/
+tests/.pioenvs/
+tests/.piolibdeps/
 
 # IDE
 .vscode/

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -276,6 +276,7 @@ namespace esphome {
                     break;
                 case climate::CLIMATE_MODE_OFF:
                     powerMode = MHI_OFF;
+                    break;
                 default:
                     break;
             }
@@ -379,8 +380,8 @@ namespace esphome {
             // Vertical air flow + 3D auto
             remote_state[11] |= swingV | _3DAuto;
 
-            // Horizontal air flow
-            remote_state[13] |= swingV | swingH;
+            // Horizontal air flow (low nibble); high nibble keeps default 0x10
+            remote_state[13] |= swingH;
 
             // Silent and Night mode
             remote_state[15] |= silentMode | nightMode;

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,0 +1,30 @@
+esphome:
+  name: mhi-test
+
+esp8266:
+  board: nodemcuv2
+
+logger:
+
+external_components:
+  - source:
+      type: local
+      path: ../esphome/components
+
+remote_receiver:
+  id: rcvr
+  pin:
+    number: GPIO14
+    inverted: true
+    mode:
+      input: true
+      pullup: true
+
+remote_transmitter:
+  pin: GPIO4
+  carrier_duty_percent: 50%
+
+climate:
+  - platform: mhi
+    name: "MHI Test"
+    receiver_id: rcvr


### PR DESCRIPTION
## Summary
Rebased onto current main after PR #2 (the `std::set` → initializer-list fix) was merged. Remaining unique changes:

- **`mhi.cpp`** — add missing `break;` after `CLIMATE_MODE_OFF` case in `transmit_state()` (was silently falling into `default`).
- **`mhi.cpp`** — drop `swingV` from `remote_state[13]`. Byte 13 stores horizontal swing in the low nibble; the receive path already masks the high nibble (`bytes[13] & 0x0F`). Looks like a copy-paste leftover from byte 11. **Hardware validation tracked in #4.**
- **`tests/test.yaml`** — minimal compile-test harness using `external_components: type: local`. Lets contributors run `esphome config tests/test.yaml` and `esphome compile tests/test.yaml` locally.
- **`.gitignore`** — ignore PlatformIO / ESPHome build artefacts under `tests/`.

## Test plan
- [x] `esphome config tests/test.yaml` — passes
- [x] `esphome compile tests/test.yaml` — builds clean against ESPHome 2026.4.0 (esp8266 / nodemcuv2)
- [ ] Hardware validation of byte-13 change — see #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)