### PR TITLE
chore: clean up climate.py imports + fix TAG declaration

### DIFF
--- a/esphome/components/mhi/climate.py
+++ b/esphome/components/mhi/climate.py
@@ -1,14 +1,12 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import climate_ir
-from esphome.const import CONF_ID
 
-AUTO_LOAD = ['climate_ir']
+AUTO_LOAD = ["climate_ir"]
+CODEOWNERS = ["@karllinder"]
 
-mhi_ns = cg.esphome_ns.namespace('mhi')
-MhiClimate = mhi_ns.class_('MhiClimate', climate_ir.ClimateIR)
+mhi_ns = cg.esphome_ns.namespace("mhi")
+MhiClimate = mhi_ns.class_("MhiClimate", climate_ir.ClimateIR)
 
-#CONFIG_SCHEMA = climate_ir.CLIMATE_IR_SCHEMA.extend({
 CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MhiClimate)
 
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome {
     namespace mhi {
-        static const char *TAG = "mhi.climate";
+        static const char *const TAG = "mhi.climate";
 
         // Power
         const uint32_t MHI_OFF = 0x08;


### PR DESCRIPTION
## Summary
Tier A — small ESPHome best-practice cleanups, no behaviour change.

**`climate.py`:**
- Remove unused imports (`CONF_ID`, `cv`).
- Remove stray commented-out `CONFIG_SCHEMA` line.
- Switch single-quoted strings to double quotes (black/upstream style).
- Add `CODEOWNERS = ["@karllinder"]` per ESPHome external-component convention.

**`mhi.cpp`:**
- `TAG`: `static const char *` → `static const char *const` (matches upstream `coolix` / `daikin` / `mitsubishi` style — the pointer itself should be const, not just the chars).

## Test plan
- [x] `esphome compile tests/test.yaml` — builds clean (esp8266 / nodemcuv2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)