### PR TITLE
ci: add lint job (ruff + clang-format)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,30 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: lint (ruff + clang-format)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff and clang-format
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff clang-format
+
+      - name: ruff check
+        run: ruff check .
+
+      - name: clang-format --dry-run -Werror
+        run: clang-format --dry-run -Werror esphome/components/mhi/*.cpp esphome/components/mhi/*.h
+
   compile:
     name: esphome compile (${{ matrix.test }})
     runs-on: ubuntu-latest

--- a/esphome/components/mhi/climate.py
+++ b/esphome/components/mhi/climate.py
@@ -1,4 +1,5 @@
 import esphome.codegen as cg
+
 from esphome.components import climate_ir
 
 AUTO_LOAD = ["climate_ir"]


### PR DESCRIPTION
## Summary
Extends CI with a `lint` job that runs in parallel with the compile matrix:

- **`ruff check .`** — uses the rules in `pyproject.toml` (E/F/I/UP rule sets).
- **`clang-format --dry-run -Werror`** on `esphome/components/mhi/*.cpp` and `*.h` — enforces the style rules from `.clang-format`.

Both tools are installed from PyPI (`pip install ruff clang-format`) — no system packages needed.

## Drive-by fix
Applied `ruff check --fix` to `climate.py` to satisfy I001 (isort wants a blank line between `import X` and `from X import Y`). Found while validating the new job locally.

## Test plan
- [x] `ruff check .` — clean locally.
- [x] `clang-format --dry-run -Werror esphome/components/mhi/*.{cpp,h}` — clean locally.
- [x] `esphome compile tests/test.esp8266-ard.yaml` — still builds (blank-line change only).
- [ ] CI — the new `lint` job should be green on this PR once GitHub runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)